### PR TITLE
Move Profiles section down to avoid undefined ref

### DIFF
--- a/configtx.yaml
+++ b/configtx.yaml
@@ -6,32 +6,6 @@
 ---
 ################################################################################
 #
-#   Profile
-#
-#   - Different configuration profiles may be encoded here to be specified
-#   as parameters to the configtxgen tool
-#
-################################################################################
-Profiles:
-
-    OneOrgOrdererGenesis:
-        Orderer:
-            <<: *OrdererDefaults
-            Organizations:
-                - *OrdererOrg
-        Consortiums:
-            SampleConsortium:
-                Organizations:
-                    - *Org1
-    OneOrgChannel:
-        Consortium: SampleConsortium
-        Application:
-            <<: *ApplicationDefaults
-            Organizations:
-                - *Org1
-
-################################################################################
-#
 #   Section: Organizations
 #
 #   - This section defines the different organizational identities which will
@@ -128,3 +102,30 @@ Application: &ApplicationDefaults
     # Organizations is the list of orgs which are defined as participants on
     # the application side of the network
     Organizations:
+
+################################################################################
+#
+#   Profile
+#
+#   - Different configuration profiles may be encoded here to be specified
+#   as parameters to the configtxgen tool
+#
+################################################################################
+Profiles:
+
+    OneOrgOrdererGenesis:
+        Orderer:
+            <<: *OrdererDefaults
+            Organizations:
+                - *OrdererOrg
+        Consortiums:
+            SampleConsortium:
+                Organizations:
+                    - *Org1
+    OneOrgChannel:
+        Consortium: SampleConsortium
+        Application:
+            <<: *ApplicationDefaults
+            Organizations:
+                - *Org1
+


### PR DESCRIPTION
The original Hyperledger Fabric configtx.yaml file had an error that is no longer tolerated in Fabric 1.2:

2018-08-09 17:13:36.523 PDT [common/tools/configtxgen/localconfig] Load -> CRIT 003 Error reading configuration:  While parsing config: yaml: unknown anchor 'OrdererDefaults' referenced
2018-08-09 17:13:36.526 PDT [common/tools/configtxgen] func1 -> CRIT 004 Error reading configuration: While parsing config: yaml: unknown anchor 'OrdererDefaults' referenced
panic: Error reading configuration: While parsing config: yaml: unknown anchor 'OrdererDefaults' referenced [recovered]
	panic: Error reading configuration: While parsing config: yaml: unknown anchor 'OrdererDefaults' referenced

This PR fixes the error so that configtxgen runs successfully:

2018-08-09 17:49:14.245 PDT [common/tools/configtxgen] doOutputBlock -> INFO 007 Generating genesis block
2018-08-09 17:49:14.251 PDT [common/tools/configtxgen] doOutputBlock -> INFO 008 Writing genesis block

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>